### PR TITLE
Fix unpermitted param :discussion_id warning

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -30,7 +30,7 @@ class PostsController < ApplicationController
 
   def update
     @post = Post.find(params.require(:id))
-    if @post.update(params.require(:post).permit(:text))
+    if @post.update(params.require(:post).permit(:text, :discussion_id))
       respond_to do |format|
         format.html { redirect_to @post.discussion }
         format.turbo_stream


### PR DESCRIPTION
Stop this appearing in the log when a post is patched:
```
Unpermitted parameter: :discussion_id. Context: { controller: PostsController, action: update, request: #<ActionDispatch::Request:0x000000010790a670>, params: {"_method"=>"patch", "authenticity_token"=>"[FILTERED]", "post"=>{"discussion_id"=>"1", "text"=>"this is about Fred."}, "controller"=>"posts", "action"=>"update", "id"=>"1"} }
```